### PR TITLE
ci: add repo guard workflow

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -1,0 +1,28 @@
+name: Repo Guard
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  guard:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ceilf6/repo-guard@main
+        with:
+          type: both
+          provider: ${{ vars.LLM_PROVIDER }}
+          model: ${{ vars.LLM_MODEL }}
+          api-key: ${{ secrets.LLM_API_KEY }}
+          base-url: ${{ vars.LLM_BASE_URL }}


### PR DESCRIPTION
## Summary

Enable Repo Guard AI review on ceilf6/Wiki.

- PR review for pull requests targeting `main`
- Issue review for newly opened issues
- Manual `@repo-guard` / `/review` comment triggers
- Skip Dependabot PRs

## GitHub Settings

- Secret `LLM_API_KEY` configured
- Variables `LLM_PROVIDER`, `LLM_BASE_URL`, `LLM_MODEL` configured